### PR TITLE
Change full name information for child and partner

### DIFF
--- a/src/components/LetterInformationHeader.ts
+++ b/src/components/LetterInformationHeader.ts
@@ -82,6 +82,12 @@ class LetterInformationHeader extends Component {
         <t t-slot="default" />
       </div>
     </div>
+
+    <div class="bg-slate-100 px-4 py-3 border-b border-solid border-slate-300 flex justify-between shadow-sm items-center z-20 relative">
+      <p class="text-gray-700 text-sm">
+        Please always signal the problem if the name of the child mentioned in the letter isn't the preferred name. Thank you.
+      </p>
+    </div>
   `;
 
   static components = {

--- a/src/components/LetterInformationHeader.ts
+++ b/src/components/LetterInformationHeader.ts
@@ -16,10 +16,6 @@ class LetterInformationHeader extends Component {
             <p class="" t-esc="props.letter.child.preferredName" />
           </div>
           <div class="flex text-sm mb-1 text-slate-800">
-            <p class="w-32  font-medium">Full Name</p>
-            <p class="" t-esc="props.letter.child.fullName" />
-          </div>
-          <div class="flex text-sm mb-1 text-slate-800">
             <p class="w-32  font-medium">Sex</p>
             <p class="" t-esc="props.letter.child.sex === 'M' ? _('Man') : _('Woman')" />
           </div>
@@ -33,10 +29,6 @@ class LetterInformationHeader extends Component {
           <div class="flex text-sm mb-1 text-slate-800">
             <p class="w-32  font-medium">Preferred Name</p>
             <p class="" t-esc="props.letter.sponsor.preferredName" />
-          </div>
-          <div class="flex text-sm mb-1 text-slate-800">
-            <p class="w-32  font-medium">Full Name</p>
-            <p class="" t-esc="props.letter.sponsor.fullName" />
           </div>
           <div class="flex text-sm mb-1 text-slate-800">
             <p class="w-32  font-medium">Sex</p>

--- a/src/models/LetterDAO.ts
+++ b/src/models/LetterDAO.ts
@@ -24,7 +24,6 @@ export type Element = Paragraph | PageBreak;
 
 export type Person = {
   preferredName: string;
-  fullName: string;
   sex: 'M' | 'F';
   age: number;
   ref: string;

--- a/src/pages/LetterEdit/LetterEditDemo.ts
+++ b/src/pages/LetterEdit/LetterEditDemo.ts
@@ -37,13 +37,11 @@ const baseState = {
     date: new Date(),
     child: {
       preferredName: 'Demo',
-      fullName: 'Child',
       sex: 'M',
       age: 12,
     },
     sponsor: {
       preferredName: 'Demo',
-      fullName: 'Sponsor',
       sex: 'F',
       age: 39,
     },


### PR DESCRIPTION
Related ticket: T0154

1. Only display the preferred name of the child as well as the sponsor

2. Add the comments in-between the Child Data and the translated text

     "Please always signal the problem if the name of the child mentioned in the letter isn't the preferred name. Thank you."
