### PR TITLE
T0173 - Add button action in translations

### DIFF
--- a/src/components/HelpModal.ts
+++ b/src/components/HelpModal.ts
@@ -1,11 +1,16 @@
-import { Component, xml, markup } from "@odoo/owl";
+import { Component, xml, markup, useState } from "@odoo/owl";
 import Modal from "./Modal";
+import TipsModal from "./TipsModal";
 import { FR, DE, GB, IT } from 'country-flag-icons/string/3x2';
 import { selectedLang, setLanguage } from "../i18n";
 import Button from "./Button";
 import { useStore } from "../store";
 import { navigateTo } from "./Router/Router";
 import t_ from "../i18n";
+
+type State = {
+  modalOpenTips?: boolean;
+};
 
 /**
  * You'll see that the template for this component would have been so much
@@ -24,8 +29,7 @@ class HelpModal extends Component {
               <li class="mb-2">I commit myself, through my translation, to respect the original message of the text as much as possible.</li>
             </ul>
             <div class="flex flex-col place-content-center">
-              <Button size="'sm'" icon="'right-from-bracket'" level="'secondary'" t-on-click="tips">Help for writing a good translation</Button>  
-              <p class="text-center">(Password: volunteer)</p>
+              <Button size="'sm'" level="'secondary'" icon="'info'" t-on-click="() => this.openTips()">Tips for a successful translation</Button>
             </div>
           </div>
         </div>
@@ -38,6 +42,8 @@ class HelpModal extends Component {
         </div>
       </div>
     </Modal>
+
+    <TipsModal onClose="() => this.state.modalOpenTips = undefined" active="state.modalOpenTips !== undefined"/>
   `;
 
   static props = ['onClose', 'active'];
@@ -45,7 +51,10 @@ class HelpModal extends Component {
   static components = {
     Modal,
     Button,
+    TipsModal,
   };
+
+  state = useState<State>({});
 
   store = useStore();
   setLanguage = setLanguage;
@@ -70,11 +79,8 @@ class HelpModal extends Component {
     );
   };
 
-  tips() {
-    window.open(
-      t_("https://porte-parole.compassion.ch/domaines/traducteurs/#cons"),
-      "_blank"
-    );
+  openTips() {
+    this.state.modalOpenTips = true;
   }
 }
 

--- a/src/components/TipsModal.ts
+++ b/src/components/TipsModal.ts
@@ -1,0 +1,66 @@
+import { Component, xml } from "@odoo/owl";
+import Modal from "./Modal";
+import Button from "./Button";
+
+
+/**
+ * This component shows the translations guidelines and tips as a pop-up
+ */
+class TipsModal extends Component {
+  static template = xml`
+    <Modal active="props.active" title="'Tips for a successful translation'" onClose="props.onClose">
+        <div class="p-4 w-300 px-10 text-sm text-slate-800">
+            <p class="font-bold mb-1">
+                Phrases in letters that must be reported to us (note in the "comments" section) so that we can inform the sponsor:
+            </p>
+            <ul class="list-disc px-5 mb-2">
+                <li>The sponsor suggests that the child come visit them in Switzerland.</li>
+                <li>Private information such as address or phone number.</li>
+                <li>Information that the sponsor has contact through Facebook or another social network.</li>
+                <li>Inappropriate expression for a child with sexual intention (you are sexy..).</li>
+                <li>Suggestion that the child would be a perfect match for a member of the sponsor's family ("I think you would be the perfect girlfriend for my son").</li>
+                <li>The sponsor asks the child to call them "mom/dad".</li>
+                <li>When the sponsor's letter mentions "I love you" too often and implies more than a friendship (ending a letter with "I love you" is accepted).</li>
+                <li>When the sponsor shares his private situation on stories of abuse (“I was beaten”).</li>
+                <li>When the sponsor suggests in the letter that they will buy a gift for the child. ("I will buy you a gift so you can buy a bike").</li>
+                <li>All photos that may evoke a sexual link (photos of naked children, large necklines, too short shorts).</li>
+            </ul>
+            <p class="font-bold mb-1">
+                Formulation for translations:
+            </p>
+            <ul class="list-disc px-5 mb-2">
+                <li>For Bible verses, simply write the Bible reference.</li>
+                <li>For the salutation, simply write "Dear Sponsor", or the sponsor/s' name.</li>
+                <li>You can use the informal "tu" pronoun when addressing the sponsors in the letter.</li>
+                <li>For the word "project" in English, the translation is "child development center".</li>
+                <li>For the date, please write it as such and do not write the date on which you are doing the translation.</li>
+            </ul>
+            <p class="font-bold mb-1">
+                Special instructions for letters from sponsors of children from Bangladesh (BD) and Sri Lanka (LK):
+            </p>
+            <p>
+                The situation in Bangladesh and Sri Lanka is sensitive. We ask sponsors to avoid the following mentions:
+            </p>
+            <ul class="list-disc px-5 mb-2">
+                <li>Asking the child to convert to the Christian faith or encouraging them to initiate a concrete Christian spiritual process.</li>
+                <li>Suggesting or writing that Christianity is superior to other religions.</li>
+                <li>Mentioning Christian practices such as baptism or the Eucharist.</li>
+            </ul>
+            <p class="font-bold text-red-500">
+                If any of these lines appear in these letters, please leave a note in the "Comments on the translation" field.
+            </p>
+        </div>
+    </Modal>
+  `;
+
+  static props = ['onClose', 'active'];
+
+  static components = {
+    Modal,
+    Button,
+  };
+
+
+}
+
+export default TipsModal;

--- a/src/pages/LetterEdit/ContentEditor.ts
+++ b/src/pages/LetterEdit/ContentEditor.ts
@@ -9,6 +9,7 @@ import _ from "../../i18n";
 type State = {
   hovered?: string | number;
   modalSourceElem?: string;
+  modalOpenHelper?: boolean;
 };
 
 type Props = {
@@ -52,10 +53,58 @@ class ContentEditor extends Component<Props> {
             <Tippy placement="'left'" content="_('Open Paragraph source text')" delay="200">
               <Button title="'Open source text'" square="true" level="'secondary'" icon="'eye'" t-on-click="() => this.openSource(element.id)" />
             </Tippy>
+            <Tippy placement="'left'" content="_('Information about the translation')" delay="200">
+              <Button title="'Information'" square="true" level="'secondary'" icon="'info'" t-on-click="() => this.openHelper()" />
+            </Tippy>
           </div>
         </div>
       </div>
     </div>
+
+    <Modal active="state.modalOpenHelper !== undefined" title="'Tips for a successful translation'" onClose="() => this.state.modalOpenHelper = undefined">
+      <div class="p-4 w-300 px-10 text-sm text-slate-800">
+        <p class="font-bold mb-1">
+          Phrases in letters that must be reported to us (note in the "comments" section) so that we can inform the sponsor:
+        </p>
+        <ul class="list-disc px-5 mb-2">
+          <li>The sponsor suggests that the child come visit them in Switzerland.</li>
+          <li>Private information such as address or phone number.</li>
+          <li>Information that the sponsor has contact through Facebook or another social network.</li>
+          <li>Inappropriate expression for a child with sexual intention (you are sexy..).</li>
+          <li>Suggestion that the child would be a perfect match for a member of the sponsor's family ("I think you would be the perfect girlfriend for my son").</li>
+          <li>The sponsor asks the child to call them "mom/dad".</li>
+          <li>When the sponsor's letter mentions "I love you" too often and implies more than a friendship (ending a letter with "I love you" is accepted).</li>
+          <li>When the sponsor shares his private situation on stories of abuse (“I was beaten”).</li>
+          <li>When the sponsor suggests in the letter that they will buy a gift for the child. ("I will buy you a gift so you can buy a bike").</li>
+          <li>All photos that may evoke a sexual link (photos of naked children, large necklines, too short shorts).</li>
+        </ul>
+        <p class="font-bold mb-1">
+          Formulation for translations:
+        </p>
+        <ul class="list-disc px-5 mb-2">
+          <li>For Bible verses, simply write the Bible reference.</li>
+          <li>For the salutation, simply write "Dear Sponsor", or the sponsor/s' name.</li>
+          <li>You can use the informal "tu" pronoun when addressing the sponsors in the letter.</li>
+          <li>For the word "project" in English, the translation is "child development center".</li>
+          <li>For the date, please write it as such and do not write the date on which you are doing the translation.</li>
+        </ul>
+        <p class="font-bold mb-1">
+          Special instructions for letters from sponsors of children from Bangladesh (BD) and Sri Lanka (LK):
+        </p>
+        <p>
+          The situation in Bangladesh and Sri Lanka is sensitive. We ask sponsors to avoid the following mentions:
+        </p>
+        <ul class="list-disc px-5 mb-2">
+          <li>Asking the child to convert to the Christian faith or encouraging them to initiate a concrete Christian spiritual process.</li>
+          <li>Suggesting or writing that Christianity is superior to other religions.</li>
+          <li>Mentioning Christian practices such as baptism or the Eucharist.</li>
+        </ul>
+        <p class="font-bold text-red-500">
+          If any of these lines appear in these letters, please leave a note in the "Comments on the translation" field.
+        </p>
+      </div>
+    </Modal>
+
     <Modal active="state.modalSourceElem !== undefined" title="'Source Text'" onClose="() => this.state.modalSourceElem = undefined">
       <div class="p-4 w-128">
         <p class="text-sm text-slate-800" t-if="state.modalSourceElem and state.modalSourceElem.trim() !== ''" t-esc="state.modalSourceElem" />
@@ -74,6 +123,7 @@ class ContentEditor extends Component<Props> {
 
   state = useState<State>({});
 
+
   _ = _;
 
   openSource(elemId: string | number) {
@@ -83,6 +133,10 @@ class ContentEditor extends Component<Props> {
     } else {
       this.state.modalSourceElem = (elem as Paragraph).source;
     }
+  }
+
+  openHelper() {
+    this.state.modalOpenHelper = true;
   }
 }
 

--- a/src/pages/LetterEdit/ContentEditor.ts
+++ b/src/pages/LetterEdit/ContentEditor.ts
@@ -4,12 +4,13 @@ import Button from '../../components/Button';
 import Modal from '../../components/Modal';
 import notyf from "../../notifications";
 import Tippy from "../../components/Tippy";
+import TipsModal from "../../components/TipsModal";
 import _ from "../../i18n";
 
 type State = {
   hovered?: string | number;
   modalSourceElem?: string;
-  modalOpenHelper?: boolean;
+  modalOpenTips?: boolean;
 };
 
 type Props = {
@@ -53,57 +54,15 @@ class ContentEditor extends Component<Props> {
             <Tippy placement="'left'" content="_('Open Paragraph source text')" delay="200">
               <Button title="'Open source text'" square="true" level="'secondary'" icon="'eye'" t-on-click="() => this.openSource(element.id)" />
             </Tippy>
-            <Tippy placement="'left'" content="_('Information about the translation')" delay="200">
-              <Button title="'Information'" square="true" level="'secondary'" icon="'info'" t-on-click="() => this.openHelper()" />
+            <Tippy placement="'left'" content="_('Tips for a successful translation')" delay="200">
+              <Button title="'Tips for a successful translation'" square="true" level="'secondary'" icon="'info'" t-on-click="() => this.openTips()" />
             </Tippy>
           </div>
         </div>
       </div>
     </div>
 
-    <Modal active="state.modalOpenHelper !== undefined" title="'Tips for a successful translation'" onClose="() => this.state.modalOpenHelper = undefined">
-      <div class="p-4 w-300 px-10 text-sm text-slate-800">
-        <p class="font-bold mb-1">
-          Phrases in letters that must be reported to us (note in the "comments" section) so that we can inform the sponsor:
-        </p>
-        <ul class="list-disc px-5 mb-2">
-          <li>The sponsor suggests that the child come visit them in Switzerland.</li>
-          <li>Private information such as address or phone number.</li>
-          <li>Information that the sponsor has contact through Facebook or another social network.</li>
-          <li>Inappropriate expression for a child with sexual intention (you are sexy..).</li>
-          <li>Suggestion that the child would be a perfect match for a member of the sponsor's family ("I think you would be the perfect girlfriend for my son").</li>
-          <li>The sponsor asks the child to call them "mom/dad".</li>
-          <li>When the sponsor's letter mentions "I love you" too often and implies more than a friendship (ending a letter with "I love you" is accepted).</li>
-          <li>When the sponsor shares his private situation on stories of abuse (“I was beaten”).</li>
-          <li>When the sponsor suggests in the letter that they will buy a gift for the child. ("I will buy you a gift so you can buy a bike").</li>
-          <li>All photos that may evoke a sexual link (photos of naked children, large necklines, too short shorts).</li>
-        </ul>
-        <p class="font-bold mb-1">
-          Formulation for translations:
-        </p>
-        <ul class="list-disc px-5 mb-2">
-          <li>For Bible verses, simply write the Bible reference.</li>
-          <li>For the salutation, simply write "Dear Sponsor", or the sponsor/s' name.</li>
-          <li>You can use the informal "tu" pronoun when addressing the sponsors in the letter.</li>
-          <li>For the word "project" in English, the translation is "child development center".</li>
-          <li>For the date, please write it as such and do not write the date on which you are doing the translation.</li>
-        </ul>
-        <p class="font-bold mb-1">
-          Special instructions for letters from sponsors of children from Bangladesh (BD) and Sri Lanka (LK):
-        </p>
-        <p>
-          The situation in Bangladesh and Sri Lanka is sensitive. We ask sponsors to avoid the following mentions:
-        </p>
-        <ul class="list-disc px-5 mb-2">
-          <li>Asking the child to convert to the Christian faith or encouraging them to initiate a concrete Christian spiritual process.</li>
-          <li>Suggesting or writing that Christianity is superior to other religions.</li>
-          <li>Mentioning Christian practices such as baptism or the Eucharist.</li>
-        </ul>
-        <p class="font-bold text-red-500">
-          If any of these lines appear in these letters, please leave a note in the "Comments on the translation" field.
-        </p>
-      </div>
-    </Modal>
+    <TipsModal onClose="() => this.state.modalOpenTips = undefined" active="state.modalOpenTips !== undefined"/>
 
     <Modal active="state.modalSourceElem !== undefined" title="'Source Text'" onClose="() => this.state.modalSourceElem = undefined">
       <div class="p-4 w-128">
@@ -119,10 +78,10 @@ class ContentEditor extends Component<Props> {
     Button,
     Tippy,
     Modal,
+    TipsModal
   };
 
   state = useState<State>({});
-
 
   _ = _;
 
@@ -135,8 +94,8 @@ class ContentEditor extends Component<Props> {
     }
   }
 
-  openHelper() {
-    this.state.modalOpenHelper = true;
+  openTips() {
+    this.state.modalOpenTips = true;
   }
 }
 


### PR DESCRIPTION
Related ticket: T0173

Added an icon below the eye icon in the translation edition
The icon opens a a pop-up saying the things that are present in the [Translation guidelines](https://porte-parole.compassion.ch/domaines/traducteurs/#cons)

Removed the Button leading to the translation guidelines external links and replaced it to call the same Tips Modal component