### PR TITLE
T0169 and T0199 Child Protection and walkthrough improvements

### DIFF
--- a/src/components/ChildModal.ts
+++ b/src/components/ChildModal.ts
@@ -44,7 +44,10 @@ class ChildModal extends Component {
     </Modal>
   `;
 
-  static props = ['onClose', 'active'];
+  static props = {
+    active: { type: Boolean },
+    onClose: { type: Function },
+  };
 
   static components = {
     Modal,

--- a/src/components/ChildModal.ts
+++ b/src/components/ChildModal.ts
@@ -12,10 +12,10 @@ import t_ from "../i18n";
  */
 class ChildModal extends Component {
   static template = xml`
-    <Modal active="props.active" title="'Child Protection'" onClose="props.onClose">
+    <Modal active="props.active" onClose="props.onClose" title="'Child Protection'">
       <div class="w-256">
         <div class="p-4">
-          <div class="flex flex-col mb-3">
+          <div class="flex flex-col mb-3 child-protection-text">
             <p class="text-sm font-semibold text-slate-700 mb-2">Here will be some text about the Child Protection part</p>
             <p class="text-sm text-slate-700 mb-2">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ornare egestas eros in ultricies. 
@@ -36,7 +36,7 @@ class ChildModal extends Component {
         </div>
         <div t-if="store.userId" class="p-4 bg-slate-100 border-t border-solid border-slate-200 flex flex-col items-center">
           <p class="text-sm font-semibold text-slate-700 mb-2">Videos</p>
-          <div class="flex flex-row space-x-4">
+          <div class="flex flex-row space-x-4 child-protection-video">
             <Button size="'sm'" icon="'right-from-bracket'" level="'secondary'" t-on-click="watchVideo">Watch the child protection video</Button>
           </div>
         </div>

--- a/src/components/ChildModal.ts
+++ b/src/components/ChildModal.ts
@@ -1,0 +1,73 @@
+import { Component, xml, markup } from "@odoo/owl";
+import Modal from "./Modal";
+import { FR, DE, GB, IT } from 'country-flag-icons/string/3x2';
+import { selectedLang, setLanguage } from "../i18n";
+import Button from "./Button";
+import { useStore } from "../store";
+import t_ from "../i18n";
+
+
+/**
+ * This component shows the Child Protection related information
+ */
+class ChildModal extends Component {
+  static template = xml`
+    <Modal active="props.active" title="'Child Protection'" onClose="props.onClose">
+      <div class="w-256">
+        <div class="p-4">
+          <div class="flex flex-col mb-3">
+            <p class="text-sm font-semibold text-slate-700 mb-2">Here will be some text about the Child Protection part</p>
+            <p class="text-sm text-slate-700 mb-2">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ornare egestas eros in ultricies. 
+              Pellentesque vel nulla urna. Morbi placerat ac purus vel pretium. Nam ornare, dolor lacinia accumsan tempus, 
+              sem orci posuere leo, non maximus libero quam vel ante. Sed tempus magna at ipsum dapibus, eu gravida elit aliquet. 
+              Proin porttitor, nulla a lacinia facilisis, massa lectus volutpat nibh, eu aliquet mi ex ac urna. Nunc vehicula mauris vitae purus dapibus sagittis.
+              Etiam aliquet nunc libero, a dapibus odio rutrum vel. Donec luctus pharetra lacus, ut dictum tellus fermentum a. Quisque ultrices sem ut dapibus vestibulum.
+              Duis pharetra non massa ut egestas. Donec faucibus nec neque non tristique. Cras vitae justo purus. In lacinia est nec maximus finibus.
+              Sed hendrerit nisi non sem scelerisque, vel aliquet tellus mollis. 
+            </p>
+          </div>
+          <p class="text-sm font-semibold text-slate-700 mb-2">Translation charter</p>
+          <ul class="list-disc ml-4 mb-4 text-sm">
+            <li class="mb-2">I agree not to disclose the information contained in the letter to be translated.</li>
+            <li class="mb-2">I agree to submit a translation as soon as possible.</li>
+            <li class="mb-2">I commit myself, through my translation, to respect the original message of the text as much as possible.</li>
+          </ul>
+        </div>
+        <div t-if="store.userId" class="p-4 bg-slate-100 border-t border-solid border-slate-200 flex flex-col items-center">
+          <p class="text-sm font-semibold text-slate-700 mb-2">Videos</p>
+          <div class="flex flex-row space-x-4">
+            <Button size="'sm'" icon="'right-from-bracket'" level="'secondary'" t-on-click="watchVideo">Watch the child protection video</Button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  `;
+
+  static props = ['onClose', 'active'];
+
+  static components = {
+    Modal,
+    Button,
+  };
+
+  store = useStore();
+  setLanguage = setLanguage;
+  selectedLang = selectedLang;
+
+  languages = {
+    fr_CH: { name: 'French', flag: markup(FR) },
+    en_US: { name: 'English', flag: markup(GB) },
+    de_DE: { name: 'German', flag: markup(DE) },
+    it_IT: { name: 'Italiano', flag: markup(IT) },
+  };
+
+  watchVideo() {
+    window.open(
+      t_("#"),
+      "_blank"
+    );
+  };
+}
+
+export default ChildModal;

--- a/src/components/HelpModal.ts
+++ b/src/components/HelpModal.ts
@@ -22,12 +22,6 @@ class HelpModal extends Component {
       <div class="w-96">
         <div class="p-4">
           <div>
-            <p class="text-center text-sm font-semibold text-slate-700 mb-2">Translation charter</p>
-            <ul class="list-disc text-center ml-4 mb-4">
-              <li class="mb-2">I agree not to disclose the information contained in the letter to be translated.</li>
-              <li class="mb-2">I agree to submit a translation as soon as possible.</li>
-              <li class="mb-2">I commit myself, through my translation, to respect the original message of the text as much as possible.</li>
-            </ul>
             <div class="flex flex-col place-content-center">
               <Button size="'sm'" level="'secondary'" icon="'info'" t-on-click="() => this.openTips()">Tips for a successful translation</Button>
             </div>
@@ -37,7 +31,6 @@ class HelpModal extends Component {
           <p class="text-sm font-semibold text-slate-700 mb-2">Tutorial</p>
           <div class="flex flex-row space-x-4">
             <Button size="'sm'" icon="'right-from-bracket'" level="'secondary'" t-on-click="startTutorial">Restart the walkthrough</Button>
-            <Button size="'sm'" icon="'right-from-bracket'" level="'secondary'" t-on-click="watchVideo">Watch the video</Button>
           </div>
         </div>
       </div>

--- a/src/components/LetterViewer.ts
+++ b/src/components/LetterViewer.ts
@@ -40,7 +40,7 @@ class LetterViewer extends Component {
                 </div>
               </div>
               <div class="flex justify-center w-full absolute top-0">
-                <div class="flex gap-2 p-2 bg-white shadow-xl -mt-12 group-hover:mt-0 transition-all">
+                <div class="flex gap-2 p-2 bg-white shadow-xl -mt-12 group-hover:mt-0 transition-all letter-viewer-actions">
                   <Button size="'sm'" level="'secondary'" onClick="() => this.state.mode = 'letter'" disabled="state.mode === 'letter'">Letter</Button>
                   <Button size="'sm'" level="'secondary'" onClick="() => this.state.mode = 'source'" disabled="state.mode === 'source'">Source</Button>
                 </div>

--- a/src/components/TipsModal.ts
+++ b/src/components/TipsModal.ts
@@ -53,7 +53,10 @@ class TipsModal extends Component {
     </Modal>
   `;
 
-  static props = ['onClose', 'active'];
+  static props = {
+    active: { type: Boolean },
+    onClose: { type: Function },
+  };
 
   static components = {
     Modal,

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -33,7 +33,8 @@ import {
   faReply,
   faOtter,
   faCheck,
-  faInfo
+  faInfo,
+  faChild
 } from '@fortawesome/free-solid-svg-icons';
 
 library.add(
@@ -64,5 +65,6 @@ library.add(
   faCaretDown,
   faOtter,
   faCheck,
-  faInfo
+  faInfo,
+  faChild
 );

--- a/src/pages/Home/index.ts
+++ b/src/pages/Home/index.ts
@@ -82,7 +82,6 @@ export default class Home extends Component {
         text: _('Next'),
         action: () => {
           this.tutorial.complete();
-          console.log('SWAG');
           navigateTo('/letters/demo-edit-letter');
         },
       }],

--- a/src/pages/Layout/Menu.ts
+++ b/src/pages/Layout/Menu.ts
@@ -4,6 +4,7 @@ import RouterLink from "../../components/Router/RouterLink";
 import MenuButton from "./MenuButton";
 import Icon from "../../components/Icon";
 import SettingsModal from "../../components/SettingsModal";
+import ChildModal from "../../components/ChildModal";
 import HelpModal from "../../components/HelpModal";
 import { getWebPath } from "../../utils";
 
@@ -29,7 +30,10 @@ class Menu extends Component {
         </MenuButton>
       </RouterLink>
       <div class="mt-auto">
-      <MenuButton tooltip="'Help'" class="'cursor-pointer'" t-on-click="() => this.state.helpModal = true">
+        <MenuButton tooltip="'Child Protection'" class="'cursor-pointer'" t-on-click="() => this.state.childModal = true">
+          <Icon prefix="'fas'" icon="'child'" class="'text-xl'" />
+        </MenuButton>
+        <MenuButton tooltip="'Help'" class="'cursor-pointer'" t-on-click="() => this.state.helpModal = true">
           <Icon prefix="'fas'" icon="'info'" class="'text-xl'" />
         </MenuButton>
         <MenuButton tooltip="'Settings'" class="'cursor-pointer'" t-on-click="() => this.state.settingsModal = true">
@@ -37,8 +41,9 @@ class Menu extends Component {
         </MenuButton>
       </div>
     </div>
-    <SettingsModal onClose="() => this.state.settingsModal = false" active="state.settingsModal" />
+    <ChildModal onClose="() => this.state.childModal = false" active="state.childModal"/>
     <HelpModal onClose="() => this.state.helpModal = false" active="state.helpModal"/>
+    <SettingsModal onClose="() => this.state.settingsModal = false" active="state.settingsModal" />
   `;
 
   static props = ['router'];
@@ -48,6 +53,7 @@ class Menu extends Component {
   static components = {
     RouterLink,
     SettingsModal,
+    ChildModal,
     HelpModal,
     MenuButton,
     Icon,
@@ -55,6 +61,7 @@ class Menu extends Component {
 
   state = useState({
     settingsModal: false,
+    childModal: false,
     helpModal: false
   });
 

--- a/src/pages/Layout/Menu.ts
+++ b/src/pages/Layout/Menu.ts
@@ -30,7 +30,7 @@ class Menu extends Component {
         </MenuButton>
       </RouterLink>
       <div class="mt-auto">
-        <MenuButton tooltip="'Child Protection'" class="'cursor-pointer'" t-on-click="() => this.state.childModal = true">
+        <MenuButton tooltip="'Child Protection'" class="'cursor-pointer child-menu-icon'" t-on-click="() => this.state.childModal = true">
           <Icon prefix="'fas'" icon="'child'" class="'text-xl'" />
         </MenuButton>
         <MenuButton tooltip="'Help'" class="'cursor-pointer'" t-on-click="() => this.state.helpModal = true">

--- a/src/pages/LetterEdit/LetterEditDemo.ts
+++ b/src/pages/LetterEdit/LetterEditDemo.ts
@@ -14,6 +14,7 @@ import LetterViewer from "../../components/LetterViewer";
 import { BlurLoader } from "../../components/Loader";
 import { navigateTo } from "../../components/Router/Router";
 import SignalProblem from "../../components/SignalProblem";
+import ChildModal from "../../components/ChildModal";
 import useCurrentTranslator from "../../hooks/useCurrentTranslator";
 import _ from "../../i18n";
 import { buildTutorial } from "../../tutorial";
@@ -59,6 +60,7 @@ const baseState = {
     ],
   },
 
+  childModal: false,
   signalProblemModal: false,
   letterSubmitted: false,
   loading: true,
@@ -81,6 +83,7 @@ class LetterEditDemo extends Component {
   currentTranslator = useCurrentTranslator();
 
   static components = {
+    ChildModal,
     SignalProblem,
     LetterViewer,
     LetterSubmittedModal,
@@ -98,6 +101,38 @@ class LetterEditDemo extends Component {
       const tutorial = buildTutorial([
         {
           text: _('Welcome to the translation editor. This small tutorial will walk you through the various tools at your disposal.'),
+        },
+        {
+          text: _('First, let\'s have a look at the Child Protection'),
+          attachTo: {
+            element: '.child-menu-icon',
+            on: 'right',
+          }
+        },
+        {
+          beforeShowPromise: () => new Promise((resolve) => {
+            this.state.childModal = true;
+            setTimeout(resolve, 300);
+          }),
+          text: _('Please make sure to carefully read the guidelines. Click on \'Next\' only when you have read and understood the guidelines.'),
+          attachTo: {
+            element: '.child-protection-text',
+            on: 'left',
+          }
+        },
+        {
+          text: _('Don\'t forget to watch our Child Protection video, come back here only after watching it'),
+          attachTo: {
+            element: '.child-protection-video',
+            on: 'left',
+          }
+        },
+        {
+          beforeShowPromise: () => new Promise((resolve) => {
+            this.state.childModal = false;
+            setTimeout(resolve, 300);
+          }),
+          text: _('As you now know everything about the Child Protection guidelines, let\'s dive into the translations functionnalities'),
         },
         {
           text: _('This panel displays the letter which you must translate, showing the text in paragraphs over one or multiple pages'),

--- a/src/pages/LetterEdit/LetterEditDemo.ts
+++ b/src/pages/LetterEdit/LetterEditDemo.ts
@@ -178,11 +178,35 @@ class LetterEditDemo extends Component {
           }
         },
         {
-          beforeShowPromise: async () => this.state.letter.pdfUrl = 'http://yoyo.emma',
-          text: _('Sometimes the PDF might not load. As an alternative you can click the "source" button which appears when you hover the panel where the letter is supposed to be'),
+          beforeShowPromise: async () => {
+            // Load invalid letter to show error on letter viewer
+            this.state.letter.pdfUrl = 'http://yoyo.emma';
+            
+            // Showing 'Letter' and 'Source' buttons in letter viewer
+            const letterViewerActions = document.querySelector('.letter-viewer-actions');
+            letterViewerActions?.classList.remove("-mt-12");
+          },
+          text: _('Sometimes the PDF might not load. As an alternative you can click the "Source" button which appears when you hover the panel where the letter is supposed to be'),
           attachTo: {
             element: '#letter-viewer',
             on: 'right',
+          },
+        },
+        {
+          beforeShowPromise: async () => {
+            
+            // Showing letter viewer in 'source' mode
+            const letterViewerActions = document.querySelector('.letter-viewer-actions');
+            const childSourceButton = letterViewerActions?.childNodes[2];
+
+            childSourceButton?.click();
+            letterViewerActions?.classList.add("-mt-12");
+
+          },
+          text: _('As you can see, after clicking on the \'Source\' button, the raw text is now visible here'),
+          attachTo: {
+            element: '#letter-viewer',
+            on: 'right'
           },
         },
         {

--- a/src/pages/LetterEdit/letterEdit.xml
+++ b/src/pages/LetterEdit/letterEdit.xml
@@ -9,6 +9,7 @@
   <!-- signal problem modal in unsafe slot (no letter) -->
   <t t-set-slot="unsafe">
     <SignalProblem active="state.signalProblemModal" letterId="props.letterId" onClose="() => state.signalProblemModal = false" />
+    <ChildModal active="state.childModal" onClose="() => state.childModal = false" />
   </t>
 
   <!-- loader for letter loading -->


### PR DESCRIPTION
Related tickets: T0169 and T0199

- Add a new icon on left menu "Child Protection"
- Remove Translation Charter part in i Icon, (on the left menu), moved it on Child Protection part
- Remove in Information part the "Watch the video" button, moved it on Child Protection part

- Add a tutorial part explaining the Child Protection
- Add a tutorial part showing that the user can select between the pdf letter or the text source on the letter translation edition
