### PR TITLE
T0303 move switch viewer button

### DIFF
--- a/src/components/LetterViewer.ts
+++ b/src/components/LetterViewer.ts
@@ -39,8 +39,8 @@ class LetterViewer extends Component {
                   <div t-if="element.type === 'pageBreak'" class="bg-slate-400 mb-2 rounded-sm text-slate-100 text-xs flex justify-center py-3">Page Break</div>
                 </div>
               </div>
-              <div class="flex justify-center w-full absolute top-0">
-                <div class="flex gap-2 p-2 bg-white shadow-xl -mt-12 group-hover:mt-0 transition-all letter-viewer-actions">
+              <div class="flex justify-center w-full absolute bottom-0">
+                <div class="flex gap-2 p-2 bg-white shadow-xl -mb-12 group-hover:-mb-0 transition-all letter-viewer-actions">
                   <Button size="'sm'" level="'secondary'" onClick="() => this.state.mode = 'letter'" disabled="state.mode === 'letter'">Letter</Button>
                   <Button class="'source-button'" size="'sm'" level="'secondary'" onClick="() => this.state.mode = 'source'" disabled="state.mode === 'source'">Source</Button>
                 </div>

--- a/src/pages/LetterEdit/LetterEditDemo.ts
+++ b/src/pages/LetterEdit/LetterEditDemo.ts
@@ -236,7 +236,7 @@ class LetterEditDemo extends Component {
             const sourceButton: HTMLElement | null = document.querySelector('.source-button');
             
             sourceButton?.click();
-            letterViewerActions?.classList.add("-mt-12");
+            letterViewerActions?.classList.add("-mb-0");
 
           },
           text: _('As you can see, after clicking on the \'Source\' button, the raw text is now visible here'),


### PR DESCRIPTION
Related ticket T0303 - The PDF/Text switch button is hiding the PDF editor controls

To make the PDF editor controls visible, I moved the switch button to the bottom of the view instead of the top.