### PR TITLE
Turn off autosave functionnality

### DIFF
--- a/src/pages/LetterEdit/index.ts
+++ b/src/pages/LetterEdit/index.ts
@@ -62,22 +62,25 @@ class LetterEdit extends Component {
     // This effect registers the auto-save functionnalities
     useEffect(() => {
       const listener = (event: KeyboardEvent) => {
-
+        
+        /* TODO Implement a better way to auto save the content
+           We are currently disabling it as it's causing user experience issues
+        */  
         // On key press, enqueue a save if necessary
-        this.queueSave();
-
+          // this.queueSave();
+        
         // If CTRL-S
-        if (event.ctrlKey && event.key === 's') {
-          event.preventDefault();
-
-          // Remove timer if any as we manually save
-          if (this.state.saveTimeout) {
-            clearTimeout(this.state.saveTimeout);
-            this.state.saveTimeout = undefined;
+          if (event.ctrlKey && event.key === 's') {
+            event.preventDefault();
+  
+            // Remove timer if any as we manually save
+            if (this.state.saveTimeout) {
+              clearTimeout(this.state.saveTimeout);
+              this.state.saveTimeout = undefined;
+            }
+            this.save(true);
           }
-          this.save(true);
         }
-      }
 
       document.addEventListener('keydown', listener);
       return () => document.removeEventListener('keydown', listener);


### PR DESCRIPTION
I turned off the auto save feature as this task is a bit complex to solve, I will go to this task again after fixing other remaining issues that needs to be fix urgently .

From now, here are my findings:
The auto save functionality is set on translation-platform-web/src/pages/LetterEdit/index.ts
inside the "useEffect()" there is a call to "this.queueSave()" that is queuing a "save()" call on each key event, with a timeout of 1.5s,

The issue is that the save function calls the update function that returns a content, therefore the old content is returned (the content saved after the 1.5s) and the content that was written during the save after the 1.5s timeout is lost. 

It's a bad practice to save a content based on a KeyboardEvent, it would be better to use the "beforeunload" event that is trigger when the user leaves the page, so we can save the content or alert the user when he does so.

For an unknown reason I was unable to get the beforeunlaod event, it's maybe related to how works the owl framework, but what we could do to make the trick would be to implement a function on the router directly, for example in ReactJS there is a way to trigger a function when the user leaves a specific route:
 ex: 
<Route
      path="/home"
      onEnter={ auth }
      onLeave={ showConfirm }
      component={ Home }
    >

I need to see how to manage this with the Owl framework, maybe it does support that, or maybe we have to create a route functionality manually...

Now that I'm writing this, I'm thinking about another way to handle this case, 
We can maybe just simply check if the user quits the text box and call the save function when a related event happens...