### PR TITLE
Show the sponsor title instead of sex

### DIFF
--- a/src/components/LetterInformationHeader.ts
+++ b/src/components/LetterInformationHeader.ts
@@ -31,8 +31,8 @@ class LetterInformationHeader extends Component {
             <p class="" t-esc="props.letter.sponsor.preferredName" />
           </div>
           <div class="flex text-sm mb-1 text-slate-800">
-            <p class="w-32  font-medium">Sex</p>
-            <p class="" t-esc="props.letter.sponsor.sex === 'M' ? _('Man') : _('Woman')" />
+            <p class="w-32  font-medium">Title</p>
+            <p class="" t-esc="props.letter.sponsor.sex === 'M' ? _('Man') : (props.letter.sponsor.sex === 'F' ? _('Woman') : props.letter.sponsor.sex)" />
           </div>
           <div class="flex text-sm text-slate-800">
             <p class="w-32  font-medium">Age</p>

--- a/src/models/LetterDAO.ts
+++ b/src/models/LetterDAO.ts
@@ -24,7 +24,7 @@ export type Element = Paragraph | PageBreak;
 
 export type Person = {
   preferredName: string;
-  sex: 'M' | 'F';
+  sex: string;
   age: number;
   ref: string;
 };


### PR DESCRIPTION
Related Ticket: T0322 - Sponsor is always declared as woman
Related pull request: https://github.com/CompassionCH/compassion-modules/pull/1787

Show the sponsor's title instead, so the translator knows how to make the salutation on the translated letter 