### PR TITLE
[T0635] We shouldn't list the letters with problems

### DIFF
--- a/src/models/BaseDAO.ts
+++ b/src/models/BaseDAO.ts
@@ -1,5 +1,5 @@
-
-type SearchDomain<T> = { column: keyof T, term: string, operator?: string };
+// When using another type than string, make sure to define an operator 
+type SearchDomain<T> = { column: keyof T, term: any, operator?: string };
 
 export interface FilterParams<T> {
   search: SearchDomain<T>[];
@@ -87,9 +87,10 @@ export function fieldSearchDomain<T>(item: SearchDomain<T>, fieldsMapping: Field
     // Using find, will match first operator, so start with 2chars operators
     const [field, formatter] = fieldMappingItems(item.column, fieldsMapping);
     const op = Object.keys(operators).find(op => item.operator === op) || 'ilike';
+    
+    // Remove operator from actual term search if term is a string type
+    const term = typeof item.term === 'string' ? item.term.replace(op, '').trim() : item.term;
 
-    // Remove operator from actual term search
-    const term = item.term.replace(op, '').trim();
     return [field, op, formatter(term)];
   }
 }

--- a/src/pages/Home/index.ts
+++ b/src/pages/Home/index.ts
@@ -140,6 +140,7 @@ export default class Home extends Component {
       search: [
         { column: 'translatorId', term: `${this.currentTranslator.data.translatorId}`, operator: '=' },
         { column: 'status', term: 'in progress' },
+        { column: 'translationIssue', term: false, 'operator': '=' },
       ]
     });
   }

--- a/src/pages/Home/index.ts
+++ b/src/pages/Home/index.ts
@@ -155,6 +155,7 @@ export default class Home extends Component {
           { column: 'status', term: 'to do' },
           { column: 'source', term: skill.source },
           { column: 'target', term: skill.target },
+          { column: 'translationIssue', term: false, operator: '=' },
         ],
       });
 


### PR DESCRIPTION
Related ticket: [T0635](https://erp.compassion.ch/web#id=1211&action=521&active_id=898&model=project.task&view_type=form&menu_id=924)

This pull request make sure that we don't show letters with translationIssue that is not set to false to users.

In the future we could improve the domain generation to implement the '|' cases and subdomains cases like 
['|', ('translationIssue', '=', False), ('translationIssue', '!=', False)]

For example this would allow us to display first the letters without problems, and then at the end the letters with problems.