### PR TITLE
T1252 english child protection video

### DIFF
--- a/src/components/ChildModal.ts
+++ b/src/components/ChildModal.ts
@@ -13,7 +13,7 @@ import t_ from "../i18n";
 class ChildModal extends Component {
   static template = xml`
     <Modal active="props.active" onClose="props.onClose" title="'Child Protection'">
-      <div class="w-256">
+      <div class="max-w-4xl">
         <div class="p-4 child-protection-text">
           <div class="flex flex-col mb-3">
             <p class="text-sm font-semibold text-slate-700 mb-2">Expected/acceptable behaviors:</p>
@@ -83,14 +83,15 @@ class ChildModal extends Component {
         </div>
         <div t-if="store.userId" class="p-4 bg-slate-100 border-t border-solid border-slate-200 flex flex-col items-center">
           <p class="text-sm font-semibold text-slate-700 mb-2">Videos</p>
-          <div class="flex flex-row space-x-4 child-protection-video">
-            <div t-if="selectedLang !== 'fr_CH' and selectedLang !== 'de_DE'">
-                <Button size="'sm'" class="'mr-5'" icon="'right-from-bracket'" level="'secondary'" t-on-click="() => watchVideo('fr_CH')">Watch the child protection video in French</Button>
-                <Button size="'sm'" icon="'right-from-bracket'" level="'secondary'" t-on-click="() => watchVideo('de_DE')">Watch the child protection video in German</Button>
-            </div>
-            <div t-else="">
+          <div class="flex flex-row flex-wrap justify-center space-x-4 child-protection-video">
+            <t t-if="selectedLang !== 'fr_CH' and selectedLang !== 'de_DE' and selectedLang !== 'en_US'">
+                <Button size="'sm'" icon="'right-from-bracket'" level="'secondary'" t-on-click="() => watchVideo('fr_CH')" class="'my-2'">Watch the child protection video in French</Button>
+                <Button size="'sm'" icon="'right-from-bracket'" level="'secondary'" t-on-click="() => watchVideo('de_DE')" class="'my-2'">Watch the child protection video in German</Button>
+                <Button size="'sm'" icon="'right-from-bracket'" level="'secondary'" t-on-click="() => watchVideo('en_US')" class="'my-2'">Watch the child protection video in English</Button>
+            </t>
+            <t t-else="">
                 <Button size="'sm'" icon="'right-from-bracket'" level="'secondary'" t-on-click="() => watchVideo()">Watch the child protection video</Button>
-            </div>
+            </t>
           </div>
         </div>
       </div>
@@ -112,7 +113,7 @@ class ChildModal extends Component {
   selectedLang = selectedLang;
 
   languages = {
-    fr_CH: { name: 'French', flag: markup(FR) },
+    fr_CH: { name: 'French', flag: markup(FR) }, 
     en_US: { name: 'English', flag: markup(GB) },
     de_DE: { name: 'German', flag: markup(DE) },
     it_IT: { name: 'Italiano', flag: markup(IT) },

--- a/src/components/ChildModal.ts
+++ b/src/components/ChildModal.ts
@@ -121,7 +121,7 @@ class ChildModal extends Component {
 
   watchVideo(targetLang?: string) {
     window.open(
-      t_("Child Protection Video Link", targetLang),
+      t_("https://drive.google.com/file/d/1p9_o89wYkbSt3F4Y71Gy3XXdbsJLp9oT/view?usp=sharing", targetLang),
       "_blank"
     );
   };

--- a/src/i18n/de_DE.json
+++ b/src/i18n/de_DE.json
@@ -247,7 +247,7 @@
     "Thank you in advance for translating as closely as possible to the original text.": "Danke, dass du möglichst nah am Originaltext übersetzt.",
     "Keep the information you handle confidential.": "Danke, dass du die Informationen vertraulich behandelst.",
     "Complete the translation of a letter as quickly as possible.": "Danke, dass du die Übersetzung eines Briefes so schnell wie möglich beendest.",
-    "Child Protection Video Link": "https://vimeo.com/838664749/b82619a911",
+    "https://drive.google.com/file/d/1p9_o89wYkbSt3F4Y71Gy3XXdbsJLp9oT/view?usp=sharing": "https://vimeo.com/838664749/b82619a911",
     "Video tutorial": "Video-Anleitung",
     "https://drive.google.com/file/d/13YqzVyTmkhBpsvVZX0v7L6rg0TRik5Fa/view": "https://drive.google.com/file/d/1oblA-oWWBP8rlkvXSZCzbK4IxS3NcTTt/view",
     "First, let's have a look at the Child Protection": "Erstens, werfen wir einen Blick auf den Kinderschutz",

--- a/src/i18n/en_US.json
+++ b/src/i18n/en_US.json
@@ -1,0 +1,3 @@
+{
+    "Child Protection Video Link": "https://drive.google.com/file/d/1p9_o89wYkbSt3F4Y71Gy3XXdbsJLp9oT/view?usp=sharing"
+}

--- a/src/i18n/en_US.json
+++ b/src/i18n/en_US.json
@@ -1,3 +1,0 @@
-{
-    "Child Protection Video Link": "https://drive.google.com/file/d/1p9_o89wYkbSt3F4Y71Gy3XXdbsJLp9oT/view?usp=sharing"
-}

--- a/src/i18n/fr_CH.json
+++ b/src/i18n/fr_CH.json
@@ -247,7 +247,7 @@
     "Thank you in advance for translating as closely as possible to the original text.": "D’avance merci de traduire au plus près possible du texte original.",
     "Keep the information you handle confidential.": "Garde les informations que tu traites de manière confidentielle.",
     "Complete the translation of a letter as quickly as possible.": "Termine la traduction d'une lettre le plus rapidement possible.",
-    "Child Protection Video Link": "https://vimeo.com/838660287/989f546368",
+    "https://drive.google.com/file/d/1p9_o89wYkbSt3F4Y71Gy3XXdbsJLp9oT/view?usp=sharing": "https://vimeo.com/838660287/989f546368",
     "Video tutorial": "Tutoriel vidéo",
     "https://drive.google.com/file/d/13YqzVyTmkhBpsvVZX0v7L6rg0TRik5Fa/view": "https://drive.google.com/file/d/117QCySOm_87Np-H3-JH_EfzCzFTwmKUl/view",
     "First, let's have a look at the Child Protection": "Tout d'abord, regardons les directives sur la protection de l'enfance",

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,5 +1,6 @@
 import fr_CH from './fr_CH.json';
 import de_DE from './de_DE.json';
+import en_US from './en_US.json';
 
 const LANG_KEY = 'translation-platform-langage-new';
 const lang = window.localStorage.getItem(LANG_KEY);
@@ -33,7 +34,8 @@ export function setLanguage(lang: string) {
  */
 const dictionnaries = {
   fr_CH,
-  de_DE
+  de_DE,
+  en_US,
 };
 
 /**

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,6 +1,5 @@
 import fr_CH from './fr_CH.json';
 import de_DE from './de_DE.json';
-import en_US from './en_US.json';
 
 const LANG_KEY = 'translation-platform-langage-new';
 const lang = window.localStorage.getItem(LANG_KEY);
@@ -35,7 +34,6 @@ export function setLanguage(lang: string) {
 const dictionnaries = {
   fr_CH,
   de_DE,
-  en_US,
 };
 
 /**


### PR DESCRIPTION
- Add the English video when viewing the page in English.
![image](https://github.com/CompassionCH/translation-platform-web/assets/100228798/6e29b7b3-c258-4e22-bd0c-d5bc28a66ef6)
- Fallback to display all videos when not in English, French, or German.
![image](https://github.com/CompassionCH/translation-platform-web/assets/100228798/49815176-5b9a-4fd3-a948-5220b1d067b2)
- Make the modal window responsive.

## Task

### Description

As the English video for the translation platform is ready, we have to add a button that links to it in the Child Protection Modal, when the user is using the platform in English.

Currently, it is displaying the French and German one in English, only the french one in french, and only the German one in German.

### To do

Remove the logic of having both German and french links in English, and add use a single button component to link the English video.
Use this video public link: [https://drive.google.com/file/d/1p9_o89wYkbSt3F4Y71Gy3XXdbsJLp9oT/view?usp=sharing](https://drive.google.com/file/d/1p9_o89wYkbSt3F4Y71Gy3XXdbsJLp9oT/view?usp=sharing)