### PR TITLE
T1160 - Number of translated letter handled incorrectly

### DIFF
--- a/src/hooks/useCurrentTranslator.ts
+++ b/src/hooks/useCurrentTranslator.ts
@@ -7,7 +7,7 @@ const watchers: Callback[] = [];
 type State = {
   loading: boolean;
   data?: Translator;
-  refresh: (userId?: number) => Promise<void>;
+  refresh: (silent?: boolean) => Promise<void>;
   loadIfNotInitialized: () => Promise<void>;
   watch: (callback: Callback) => void;
 };
@@ -24,8 +24,8 @@ const state = reactive<State>({
   loading: false,
   data: undefined as Translator | undefined,
 
-  async refresh() {
-    this.loading = true;
+  async refresh(silent = false) {
+    this.loading = this.loading || !silent;
     this.data = await models.translators.current();
     this.loading = false;  
   },

--- a/src/pages/LetterEdit/index.ts
+++ b/src/pages/LetterEdit/index.ts
@@ -64,20 +64,20 @@ class LetterEdit extends Component {
       const listener = (event: KeyboardEvent) => {
 
         // On key press, enqueue a save if necessary
-          this.queueSave();
-        
+        this.queueSave();
+
         // If CTRL-S
-          if (event.ctrlKey && event.key === 's') {
-            event.preventDefault();
-  
-            // Remove timer if any as we manually save
-            if (this.state.saveTimeout) {
-              clearTimeout(this.state.saveTimeout);
-              this.state.saveTimeout = undefined;
-            }
-            this.save(true);
+        if (event.ctrlKey && event.key === 's') {
+          event.preventDefault();
+
+          // Remove timer if any as we manually save
+          if (this.state.saveTimeout) {
+            clearTimeout(this.state.saveTimeout);
+            this.state.saveTimeout = undefined;
           }
+          this.save(true);
         }
+      }
 
       document.addEventListener('keydown', listener);
       return () => document.removeEventListener('keydown', listener);
@@ -134,7 +134,7 @@ class LetterEdit extends Component {
       this.state.letter.translatorId = this.currentTranslator.data?.translatorId
     }
 
-    const res = await models.letters.update({...this.state.letter as Letter});
+    const res = await models.letters.update({ ...this.state.letter as Letter });
 
     if (!res) {
       notyf.error(_('Unable to save letter'));
@@ -144,8 +144,9 @@ class LetterEdit extends Component {
       }
 
       // The score changed so the translator must be refreshed.
+      // NOTE: this is a visual side effect so no await.
       if (newAttribution) {
-        this.currentTranslator.refresh(true)
+        this.currentTranslator.refresh(true);
       }
     }
 

--- a/src/pages/LetterEdit/index.ts
+++ b/src/pages/LetterEdit/index.ts
@@ -126,7 +126,11 @@ class LetterEdit extends Component {
     if (!this.currentTranslator.data) {
       await this.currentTranslator.refresh();
     }
-    if (!this.state.letter.translatorId) {
+
+    // If this letter hasn't been attributed, we attribute ourselves
+    // and our score will increase.
+    const newAttribution = !this.state.letter.translatorId;
+    if (newAttribution) {
       this.state.letter.translatorId = this.currentTranslator.data?.translatorId
     }
 
@@ -137,6 +141,11 @@ class LetterEdit extends Component {
     } else {
       if (!background) {
         notyf.success(_('Letter saved'));
+      }
+
+      // The score changed so the translator must be refreshed.
+      if (newAttribution) {
+        this.currentTranslator.refresh(true)
       }
     }
 


### PR DESCRIPTION
- Refresh the user after saving a letter.
- Edit user refresh to allow silent background refresh without prompting the loading screen.

### Note
Ran format on `src/pages/LetterEdit/index.ts`, some indentation changes are included.

CompassionCH/compassion-modules#1938