### PR TITLE
T1796 - Letter's comments are flooding chatter

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,3 +10,9 @@ export const RPC_FAULT_CODE_APPLICATION_ERROR = 1
 export const RPC_FAULT_CODE_WARNING = 2
 export const RPC_FAULT_CODE_ACCESS_DENIED = 3
 export const RPC_FAULT_CODE_ACCESS_ERROR = 4
+
+/**
+ * Defines the delay (in milliseconds) between the last user key press and the following auto-save to the backend.
+ * Warning: setting this value too low (e.g. 1500) causes auto-saves to happen mid-sentence for people who type slowly. This in turn causes flooding of the comment logs on chatter (see T1796).
+ */
+export const LETTER_EDIT_AUTOSAVE_DELAY_MS = 10_000;

--- a/src/pages/LetterEdit/index.ts
+++ b/src/pages/LetterEdit/index.ts
@@ -11,6 +11,7 @@ import { BlurLoader } from '../../components/Loader';
 import LetterSubmittedModal from "./LetterSubmittedModal";
 import _ from "../../i18n";
 import useCurrentTranslator from "../../hooks/useCurrentTranslator";
+import { LETTER_EDIT_AUTOSAVE_DELAY_MS } from "../../constants";
 
 type State = {
   dirty: false;
@@ -109,8 +110,8 @@ class LetterEdit extends Component {
       clearTimeout(this.state.saveTimeout);
     }
 
-    // Set the timer to automatically save in 1,5 secs
-    this.state.saveTimeout = setTimeout(() => this.save(true), 1500);
+    // Set the timer to automatically save in LETTER_EDIT_AUTOSAVE_DELAY_MS milliseconds
+    this.state.saveTimeout = setTimeout(() => this.save(true), LETTER_EDIT_AUTOSAVE_DELAY_MS);
   }
 
   async save(background = false) {


### PR DESCRIPTION
This PR provides a very simple and stupid solution to the chatter flooding problem. 
The solution is to increase the auto-save delay to 10 seconds. This should prevent the generation of too many chatter logs for comment updates even for people who type very slowly. 

