### PR TITLE
feat: add dev hack for authentication to access translation platform

### DIFF
--- a/src/models/OdooAPI.ts
+++ b/src/models/OdooAPI.ts
@@ -48,94 +48,57 @@ async function fetchJson(uri: string, body: any, verb = 'POST'): Promise<any> {
   const res = await fetch(import.meta.env.VITE_ODOO_URL + uri, {
     method: verb,
     body: JSON.stringify(body),
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-      // TODO: pass language to get localized error.
-      // "Accept-Language": selectedLang,
-    }
+    headers: { "Content-Type": "application/json", Accept: "application/json" }
   });
 
-  if (!res.ok) {
-    throw new Error(`Failed to refresh. Returned ${res.status}: "${res.statusText}"`)
-  }
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
 
-  const payload = JSON.parse(await res.text());
-  if (payload.error) {
-    throw payload.error.data;
-  }
+  const payload = await res.json();
+  if (payload.error) throw payload.error.data;
 
   return payload.result;
 }
 
-// Buffered token refresh.
-const refreshListeners: ((tokens?: AuthTokens, err?: any) => void)[] = [];
-function refreshAccessToken(): Promise<AuthTokens> {
-  const operationCompleted =
-    (tokens?: AuthTokens, err?: any) => {
-      refreshListeners.forEach(l => l(tokens, err));
-      refreshListeners.length = 0;
-    };
-
-  return new Promise(async (res, rej) => {
-    refreshListeners.push((tokens, err) => tokens ? res(tokens) : rej(err));
-
-    // A refresh request is pending, wait for it and do nothing.
-    if (refreshListeners.length !== 1) {
-      return;
-    }
-
-    let authTokens: AuthTokens | null = null;
-    try {
-      authTokens = await fetchJson('/auth/refresh', {
-        refresh_token: store.refreshToken,
-      });
-    }
-    catch (e) {
-      operationCompleted(undefined, e);
-      return;
-    }
-
-    store.accessToken = authTokens?.access_token;
-    store.accessTokenExpiresAt = authTokens?.expires_at;
-    store.refreshToken = authTokens?.refresh_token;
-
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
-
-    operationCompleted(authTokens!);
-  })
+async function refreshAccessToken(): Promise<AuthTokens> {
+  return {
+    access_token: store.accessToken!,
+    refresh_token: store.refreshToken!,
+    expires_at: store.accessTokenExpiresAt!
+  };
 }
 
-
 const OdooAPI = {
-
-  /**
-   * Attempts to authenticate the user given a username, a password, and optionally
-   * a totp.
-   * @param username the username
-   * @param password the password
-   * @returns True if the credentials are valid or the server error.
-   */
-  async authenticate(username: string, password: string, totp?: string): Promise<true | any> {
+  async authenticate(username: string, password: string): Promise<true | any> {
     try {
-      const { user_id, auth_tokens }: AuthResponse = await fetchJson('/auth/login', {
-        "login": username, // username is called login in res_partner
+      const commonClient = new XmlRpcClient(import.meta.env.VITE_ODOO_URL + "/xmlrpc/2/common");
+      const uid = await commonClient.methodCall('authenticate', [
+        import.meta.env.VITE_ODOO_DBNAME,
+        username,
         password,
-        totp,
+        {}
+      ]);
+
+      if (!uid) throw new Error("user invalid");
+
+      const authTokens: AuthTokens = {
+        access_token: password,
+        refresh_token: "native-xmlrpc",
+        expires_at: "2099-01-01T00:00:00.000Z"
+      };
+
+      Object.assign(store, {
+        version: STORE_VERSION,
+        userId: Number(uid),
+        username,
+        accessToken: authTokens.access_token,
+        refreshToken: authTokens.refresh_token,
+        accessTokenExpiresAt: authTokens.expires_at
       });
 
-      store.version = STORE_VERSION;
-      store.userId = user_id;
-      store.username = username;
-      store.accessToken = auth_tokens.access_token;
-      store.refreshToken = auth_tokens.refresh_token;
-      store.accessTokenExpiresAt = auth_tokens.expires_at;
-
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
 
       return true;
-    }
-    catch (e: any) {
+    } catch (e: any) {
       console.warn("Failed to authenticate: ", e);
       return e;
     }
@@ -147,60 +110,39 @@ const OdooAPI = {
   },
 
   async logout(): Promise<void> {
-    const route = '/auth/logout';
-    const refresh_token = store.refreshToken;
-    try {
-      const resp = await fetchJson(route, { refresh_token });
-      console.log(`Logout succeeded: ${resp}`);
-    } catch (error) {
-      console.warn(`Request to ${route} failed. This means that the refresh_token was probably not revoked on the backend. This is only a security risk if the refresh_token was intercepted by a malicious actor. In all cases, it will automatically expire when its expiration datetime is reached. Anyway, there's not much we can do at this point except clear to tokens in local storage.`);
-      throw error;
-    }
+    console.log("Logout bypassed for development mode");
+    clearStoreCache();
+    return Promise.resolve();
   },
 
   async executeWithOptions_kw<T>(model: string, method: string, options: ExecuteKwOptions, ...args: any[]): Promise<T | undefined> {
-    if (store.accessToken && !options.password) {
-      const refreshMarginMs = 10 * 1000;
-      // refresh the accessToken if it's going to expire in the next refreshMarginMs milliseconds;
-      if (options.refreshIfExpired !== false && (new Date(store.accessTokenExpiresAt ?? '').getTime()) < Date.now() + refreshMarginMs) {
-        try {
-          await refreshAccessToken();
-        }
-        catch (e) {
-          clearStoreCache();
-          throw e;
-        }
-      }
-
-      setClientHeader('Authorization', 'Bearer ' + store.accessToken);
-    }
-    else if (!options.password) {
-      // No token or password. Request will fail.
-      console.warn("Tried to execute a request without credentials.")
+    if (!store.accessToken && !options.password) {
+      console.warn("Tried to execute a request without credentials.");
       return;
     }
+    const refreshMarginMs = 10_000;
+    if (store.accessToken && options.refreshIfExpired !== false &&
+        new Date(store.accessTokenExpiresAt!).getTime() < Date.now() + refreshMarginMs) {
+      try { await refreshAccessToken(); } catch { clearStoreCache(); return; }
+    }
+
+    setClientHeader('Authorization', 'Bearer ' + store.accessToken);
 
     try {
       args.push({ context: { lang: selectedLang } });
       const response = await apiClient.methodCall('execute_kw', [
         import.meta.env.VITE_ODOO_DBNAME,
         store.userId,
-        options.password ?? 'None',
+        options.password ?? store.accessToken,
         model,
         method,
-        ...args,
+        ...args
       ]);
 
       return response as any as T;
     } catch (e: any) {
-
-      if (
-          e.code === RPC_FAULT_CODE_ACCESS_ERROR ||
-          e.code === RPC_FAULT_CODE_ACCESS_DENIED
-      ) {
-        notyf.error(_('Oops! There is an issue with your account. Please contact Compassion for further assistance.'));
-
-        // Reset cache when the error is related to a user login issue
+      if ([RPC_FAULT_CODE_ACCESS_ERROR, RPC_FAULT_CODE_ACCESS_DENIED].includes(e.code)) {
+        console.warn("Access denied ignored in dev mode.", e);
         clearStoreCache();
 
 
@@ -214,7 +156,7 @@ const OdooAPI = {
 
   async execute_kw<T>(model: string, method: string, ...args: any[]): Promise<T | undefined> {
     return await this.executeWithOptions_kw(model, method, {}, ...args);
-  },
-}
+  }
+};
 
 export default OdooAPI;


### PR DESCRIPTION

Introduce a temporary authentication workaround to allow connection to the translation platform without relying on the auth_external module.

This implementation uses native XML-RPC authentication and treats the user password as an access token, while keeping the overall API structure compatible with the future token-based system.

This is a temporary solution intended for development purposes only and will be removed once the migration to auth_external is completed.