### PR TITLE
[T2784] FIX : Correct spelling typo in walkthrough tutorial text

### DIFF
--- a/src/i18n/de_DE.json
+++ b/src/i18n/de_DE.json
@@ -72,7 +72,7 @@
     "Note that those elements are not locked, which means you can move and remove them as you want": "Beachte, dass diese Elemente nicht fixiert sind, d.h. du kannst sie nach Belieben verschieben und entfernen.",
     "Notify Compassion of a problem with this letter": "Melde Compassion ein Problem mit diesem Brief.",
     "of": "auf",
-    "Once clicking it, you will be brought here where your can select a problem and provide additional details to the Compassion team": "Hier kannst du das aufgetretene Problem aussuchen und erklären.",
+    "Once clicking it, you will be brought here where you can select a problem and provide additional details to the Compassion team": "Hier kannst du das aufgetretene Problem aussuchen und erklären.",
     "Open in Editor": "Bearbeitung öffnen",
     "Open Paragraph source text": "Ausgangstext des Absatzes öffnen",
     "Page Break": "Seitenumbruch",

--- a/src/i18n/fr_CH.json
+++ b/src/i18n/fr_CH.json
@@ -72,7 +72,7 @@
     "Note that those elements are not locked, which means you can move and remove them as you want": "Ces éléments ne sont pas verrouillés, tu peux donc les déplacer et les supprimer.",
     "Notify Compassion of a problem with this letter": "Informer l'équipe de Compassion d'un problème avec cette lettre.",
     "of": "sur",
-    "Once clicking it, you will be brought here where your can select a problem and provide additional details to the Compassion team": "Une fois cliqué, tu seras amené ici où tu pourras sélectionner la cause principale du problème et fournir des détails supplémentaires à l'équipe de Compassion.",
+    "Once clicking it, you will be brought here where you can select a problem and provide additional details to the Compassion team": "Une fois cliqué, tu seras amené ici où tu pourras sélectionner la cause principale du problème et fournir des détails supplémentaires à l'équipe de Compassion.",
     "Open in Editor": "Ouvrir dans l'éditeur",
     "Open Paragraph source text": "Ouvrir le texte source du paragraphe",
     "Page Break": "Saut de Page",

--- a/src/pages/LetterEdit/LetterEditDemo.ts
+++ b/src/pages/LetterEdit/LetterEditDemo.ts
@@ -200,7 +200,7 @@ class LetterEditDemo extends Component {
             this.state.signalProblemModal = true;
             setTimeout(resolve, 300);
           }),
-          text: _('Once clicking it, you will be brought here where your can select a problem and provide additional details to the Compassion team'),
+          text: _('Once clicking it, you will be brought here where you can select a problem and provide additional details to the Compassion team'),
           attachTo: {
             element: '.modal',
             on: 'bottom',


### PR DESCRIPTION
### Goal
Fix a spelling mistake in the platform tutorial:
* **Before:** "...where you<u>r</u> can select..."
* **After:** "...where you can select..."

### Technical Aspects
- Modified the associated string in `LetterEditDemo.ts`
- Updated the translation strings in the corresponding `.js` localization files